### PR TITLE
gnrc_sixlowpan_iphc: use UNDEF if UDP module not available

### DIFF
--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -77,7 +77,7 @@ typedef enum {
 #ifdef MODULE_GNRC_TCP
     GNRC_NETTYPE_TCP,           /**< Protocol is TCP */
 #endif
-#if defined(MODULE_GNRC_UDP) || defined(MODULE_GNRC_SIXLOWPAN_IPHC_NHC)
+#ifdef MODULE_GNRC_UDP
     GNRC_NETTYPE_UDP,           /**< Protocol is UDP */
 #endif
     /**

--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -118,8 +118,13 @@ inline static size_t iphc_nhc_udp_decode(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t **d
     uint8_t *payload = pkt->data;
     gnrc_pktsnip_t *ipv6 = *dec_hdr;
     ipv6_hdr_t *ipv6_hdr = ipv6->data;
+#ifdef MODULE_GNRC_UDP
+    const gnrc_nettype_t snip_type = GNRC_NETTYPE_UDP;
+#else
+    const gnrc_nettype_t snip_type = GNRC_NETTYPE_UNDEF;
+#endif
     gnrc_pktsnip_t *udp = gnrc_pktbuf_add(NULL, NULL, sizeof(udp_hdr_t),
-                                          GNRC_NETTYPE_UDP);
+                                          snip_type);
     uint8_t udp_nhc = payload[offset++];
     uint8_t tmp;
 


### PR DESCRIPTION
There is no need to mark the packet snip as UDP if there is no UDP handler.